### PR TITLE
Trying to add an option to use variables while calling the api.models.my...

### DIFF
--- a/initializers/sequelize.js
+++ b/initializers/sequelize.js
@@ -3,7 +3,8 @@ var fs                = require('fs');
 var Sequelize         = require('sequelize');
 
 exports.sequelize = function(api, next){
-  
+
+    //I wonder if we need to change this part at all. Find and Create actions on the sequelize model work just fine.
   api.models = {};
 
   api.sequelize = {
@@ -73,7 +74,7 @@ exports.sequelize = function(api, next){
         console.log(err);
         process.exit();
       });
-    },
+    }
 
   }
 


### PR DESCRIPTION
Hi Evan,

I have been looking at the sequelize.js initializer but I'm over my head I guess.
Can't figure out why a variable submission doesn't work at this point. api.models.mymodel.create() or .findall also add variables which work.

The initializer basically doesn't change anything so I don't quite understand why it isn't working already.

Or is it something sequelize itself doesn't support? I haven't been able to find anything abou this in the documentation of sequelize. Nor any examples that try something like this..
