### PR TITLE
no longer assume model and migration paths are relative to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 npm-debug.log
 node_modules/*
 .vscode
+log
+pids
+ActionheroWebsocketClient*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![plugin](https://i.imgur.com/nd1btLt.png)
+
 # ah-sequelize-plugin
 
 [![CircleCI](https://circleci.com/gh/actionhero/ah-sequelize-plugin.svg?style=svg)](https://circleci.com/gh/actionhero/ah-sequelize-plugin)
@@ -6,6 +7,7 @@
 This plugin will use the sequelize orm to create `api.models` which contain your sequelize models.
 
 ## Notes
+
 Versions `1.0.0+` are only compatible with ActionHero versions `18.0.0+`.
 
 For versions compatible with ActionHero versions prior to `18.0.0`, use version [`0.9.0`](https://github.com/actionhero/ah-sequelize-plugin/releases/tag/v0.9.0).
@@ -17,16 +19,19 @@ For versions compatible with ActionHero versions prior to `18.0.0`, use version 
 - Add plugin to your project's `./config/plugins.js`:
 
 ```javascript
-exports['default'] = {
-  plugins: (api) => {
+exports["default"] = {
+  plugins: api => {
     return {
-      'ah-sequelize-plugin': { path: __dirname + '/../node_modules/ah-sequelize-plugin' }
-    }
+      "ah-sequelize-plugin": {
+        path: __dirname + "/../node_modules/ah-sequelize-plugin"
+      }
+    };
   }
-}
+};
 ```
 
 ### Add supported database packages
+
 - MySQL: `npm install mysql2 --save`
 - SQLite: `npm install sqlite3 --save`
 - Postgress: `npm install --save pg pg-hstore`
@@ -35,43 +40,66 @@ exports['default'] = {
 For additional information on supported databases visit the [Sequelize Docs](http://docs.sequelizejs.com/manual/installation/getting-started).
 
 ### Add optional dependencies
+
 - For automatic fixures: `npm install sequelize-fixtures --save`
 - For Sequelize CLI: `npm install --save-dev sequelize-cli`
 
 ### Configuration
 
-A `./config/sequelize.js` file will be created which will store your database configuration.  Read commented sections of configuration file for examples of multi-environment configurations.
+A `./config/sequelize.js` file will be created which will store your database configuration. Read commented sections of configuration file for examples of multi-environment configurations.
 
 To override the default location for models and/or migrations, use the `modelsDir` and `migrationsDir` configuration parameter with an array of paths relative to the project root.
 
 ```javascript
-const { URL } = require('url')
+const { URL } = require("url");
 
-const databaseBaseName = 'my-app'
+const databaseBaseName = "my-app";
 
 exports.default = {
-  sequelize: (api) => {
-    let dialect = 'postgres'
-    let host = process.env.DB_HOST || '127.0.0.1'
-    let port = process.env.DB_PORT || 5432
-    let database = process.env.DB_DATABASE || `${databaseBaseName}_${api.env}${process.env.JEST_WORKER_ID ? '_' + process.env.JEST_WORKER_ID : ''}`
-    let username = process.env.DB_USER || undefined
-    let password = process.env.DB_PASS || undefined
+  sequelize: api => {
+    let dialect = "postgres";
+    let host = process.env.DB_HOST || "127.0.0.1";
+    let port = process.env.DB_PORT || 5432;
+    let database =
+      process.env.DB_DATABASE ||
+      `${databaseBaseName}_${api.env}${
+        process.env.JEST_WORKER_ID ? "_" + process.env.JEST_WORKER_ID : ""
+      }`;
+    let username = process.env.DB_USER || undefined;
+    let password = process.env.DB_PASS || undefined;
 
     // if your environment provides database information via a single JDBC-style URL like mysql://username:password@hostname:port/default_schema
-    const connectionURL = process.env.DATABASE_URL || process.env.MYSQL_URL || process.env.PG_URL || process.env.JAWSDB_URL
+    const connectionURL =
+      process.env.DATABASE_URL ||
+      process.env.MYSQL_URL ||
+      process.env.PG_URL ||
+      process.env.JAWSDB_URL;
 
     if (connectionURL) {
-      const parsed = new URL(connectionURL)
-      if (parsed.protocol) { dialect = parsed.protocol.slice(0, -1) }
-      if (parsed.username) { username = parsed.username }
-      if (parsed.password) { password = parsed.password }
-      if (parsed.hostname) { host = parsed.hostname }
-      if (parsed.port) { port = parsed.port }
-      if (parsed.pathname) { database = parsed.pathname.substring(1) }
+      const parsed = new URL(connectionURL);
+      if (parsed.protocol) {
+        dialect = parsed.protocol.slice(0, -1);
+      }
+      if (parsed.username) {
+        username = parsed.username;
+      }
+      if (parsed.password) {
+        password = parsed.password;
+      }
+      if (parsed.hostname) {
+        host = parsed.hostname;
+      }
+      if (parsed.port) {
+        port = parsed.port;
+      }
+      if (parsed.pathname) {
+        database = parsed.pathname.substring(1);
+      }
     }
 
-    if (dialect === 'postgresql') { dialect = 'postgres' }
+    if (dialect === "postgresql") {
+      dialect = "postgres";
+    }
 
     return {
       autoMigrate: true,
@@ -83,29 +111,31 @@ exports.default = {
       host: host,
       username: username,
       password: password,
-      modelsDir: ['models'],
-      migrationsDir: ['migrations']
-    }
+      modelsDir: [path.join(__dirname, "..", "models")],
+      migrationsDir: [path.join(__dirname, "..", "migrations")],
+      fixturesMatch: [
+        path.join(__dirname, "..", "/__tests__/fixtures/*.{json,yml,js}")
+      ]
+    };
   }
-}
+};
 ```
 
 #### Logging
 
-The `logging` configuration parameter accepts either a `false` value, or a function which accepts a log value of type `string` and a event level value of type `string` (ex: `console.log`, `api.log`).  If you are passing in a function for the logging parameter, you must also set the `_toExpand` config parameter to `false` in order for the logging function to not be called during ActionHero startup.
+The `logging` configuration parameter accepts either a `false` value, or a function which accepts a log value of type `string` and a event level value of type `string` (ex: `console.log`, `api.log`). If you are passing in a function for the logging parameter, you must also set the `_toExpand` config parameter to `false` in order for the logging function to not be called during ActionHero startup.
 
 ```javascript
 exports.test = {
   ...exports.default.sequelize(),
   sequelize: () => {
     return {
-      '_toExpand': false,
-      'database': 'TEST_DB',
-      'logging': console.log
-    }
+      _toExpand: false,
+      database: "TEST_DB",
+      logging: console.log
+    };
   }
-}
-
+};
 ```
 
 ## [Models](http://docs.sequelizejs.com/en/latest/api/models)
@@ -115,48 +145,52 @@ Use the exports form of sequelize models in `./models` with the file name matchi
 ```javascript
 // from ./models/user.js
 
-module.exports = function (sequelize, DataTypes, api) {
-
+module.exports = function(sequelize, DataTypes, api) {
   // Define model structure and options
-  const model = sequelize.define('user', {
-    id: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      autoIncrement: true,
-      primaryKey: true
+  const model = sequelize.define(
+    "user",
+    {
+      id: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        autoIncrement: true,
+        primaryKey: true
+      }
+    },
+    {
+      paranoid: true
     }
-  }, {
-    paranoid: true
-  })
+  );
 
   // Attach Class methods
-  model.rehydrate = function (user) {
-    return this.build(user)
-  }
+  model.rehydrate = function(user) {
+    return this.build(user);
+  };
 
   // Attach Instance methods
-  model.prototype.apiData = function () {
+  model.prototype.apiData = function() {
     return {
       id: this.id
-    }
-  }
+    };
+  };
 
-  return model
-}
+  return model;
+};
 ```
 
 Models are loaded into `api.models`, so the example above would be `api.models.user`. These module.exports allow for a third optional parameter "api" which is the ActionHero API object. This can be used to access configs and initializer functions, among other things.
 
 ## [Migrations](http://docs.sequelizejs.com/en/latest/api/migrations)
 
-This plugin does not condone the use of `Sequelize.sync()` in favor of migrations.  Keep you migrations in `./migrations` and use the [sequelize-cli](https://github.com/sequelize/cli) to execute them.
+This plugin does not condone the use of `Sequelize.sync()` in favor of migrations. Keep you migrations in `./migrations` and use the [sequelize-cli](https://github.com/sequelize/cli) to execute them.
 
 An example migration to create a `users` table would look like:
+
 ```javascript
 // from ./migrations/20140101000001-create-users.js
 
 module.exports = {
-  up: async function (migration, DataTypes) {
-    await migration.createTable('users', {
+  up: async function(migration, DataTypes) {
+    await migration.createTable("users", {
       id: {
         type: DataTypes.INTEGER,
         primaryKey: true,
@@ -169,28 +203,28 @@ module.exports = {
       passwordSalt: DataTypes.TEXT,
       createdAt: DataTypes.DATE,
       updatedAt: DataTypes.DATE
-    })
+    });
 
-    await migration.addIndex('users', ['email'], {
-      indexName: 'email_index',
-      indicesType: 'UNIQUE'
-    })
+    await migration.addIndex("users", ["email"], {
+      indexName: "email_index",
+      indicesType: "UNIQUE"
+    });
 
-    await migration.addIndex('users', ['name'], {
-      indexName: 'name_index',
-      indicesType: 'UNIQUE'
-    })
+    await migration.addIndex("users", ["name"], {
+      indexName: "name_index",
+      indicesType: "UNIQUE"
+    });
 
-    await migration.addIndex('users', ['phone'], {
-      indexName: 'phone_index',
-      indicesType: 'UNIQUE'
-    })
+    await migration.addIndex("users", ["phone"], {
+      indexName: "phone_index",
+      indicesType: "UNIQUE"
+    });
   },
 
-  down: async function (migration, DataTypes) {
-    await migration.dropTable('users')
+  down: async function(migration, DataTypes) {
+    await migration.dropTable("users");
   }
-}
+};
 ```
 
 You can use the [sequelize-cli](http://docs.sequelizejs.com/en/latest/docs/migrations/) to create and execute migrations.
@@ -207,43 +241,44 @@ By default, `ah-sequelize-plugin` will automatically execute any pending migrati
 If you want to declare associations, best practice has you define an `.associate()` class method in your model such as:
 
 ```javascript
-module.exports = function (sequelize, DataTypes, api) {
-  const model = sequelize.define('user', {
+module.exports = function(sequelize, DataTypes, api) {
+  const model = sequelize.define("user", {
     id: {
       type: DataTypes.INTEGER.UNSIGNED,
       autoIncrement: true,
       primaryKey: true
     }
-  })
+  });
 
-  model.associate = function (models) {
-    this.hasMany(models.email)
-  }
+  model.associate = function(models) {
+    this.hasMany(models.email);
+  };
 
-  return model
-}
+  return model;
+};
 ```
 
 Then you create an `associations.js` initializer within your project which might look like this:
 
 ```javascript
-const { Initializer, api } = require('actionhero')
+const { Initializer, api } = require("actionhero");
 
 module.exports = class AssociationsInitializer extends Initializer {
-  constructor () {
-    super()
-    this.name = 'AssociationsInitializer'
+  constructor() {
+    super();
+    this.name = "AssociationsInitializer";
   }
 
-  start () {
-    Object.entries(api.models).filter(([k, m]) => typeof m.associate === 'function')
-      .forEach(([k, m]) => m.associate(api.models))
+  start() {
+    Object.entries(api.models)
+      .filter(([k, m]) => typeof m.associate === "function")
+      .forEach(([k, m]) => m.associate(api.models));
   }
-}
+};
 ```
 
 ## [Fixtures](https://github.com/domasx2/sequelize-fixtures)
 
-We use the `sequelize-fixtures` package to load in JSON-defined fixtures in the test NODE\_ENV.  Store your fixtures in `./test/fixtures/*.json` or `./test/fixtures/*.yml`.
+We use the `sequelize-fixtures` package to load in JSON-defined fixtures in the test NODE_ENV. Store your fixtures in `./test/fixtures/*.json` or `./test/fixtures/*.yml`.
 
 By default, `ah-sequelize-plugin` will **not** automatically load your fixtures when Actionhero starts up. You can enable this behavior by adding `loadFixtures: true` to your sequelize config.

--- a/classes/sequelize.js
+++ b/classes/sequelize.js
@@ -5,142 +5,159 @@ const { api } = require('actionhero')
 const Sequelize = require('sequelize')
 const config = api.config.sequelize
 
-module.exports =
-  class SequelizePlugin {
-    constructor () {
-      config.logging = config.logging !== false ? config.logging || api.log : () => { }
+module.exports = class SequelizePlugin {
+  constructor () {
+    config.logging =
+      config.logging !== false ? config.logging || api.log : () => {}
 
-      this.sequelize = new Sequelize(
-        config.database,
-        config.username,
-        config.password,
-        config
+    this.sequelize = new Sequelize(
+      config.database,
+      config.username,
+      config.password,
+      config
+    )
+
+    this.umzug = []
+    this.importMigrationsFromDirectory(config.migrationsDir || ['migrations'])
+  }
+
+  importMigrationsFromDirectory (dir) {
+    (Array.isArray(dir) ? dir : [dir]).forEach(dir => {
+      this.umzug.push(
+        new Umzug({
+          storage: 'sequelize',
+          storageOptions: {
+            sequelize: this.sequelize
+          },
+          migrations: {
+            params: [
+              this.sequelize.getQueryInterface(),
+              this.sequelize.constructor,
+              () => {
+                throw new Error(
+                  'Migration tried to use old style "done" callback. Please upgrade to "umzug" and return a promise instead.'
+                )
+              }
+            ],
+            path: dir,
+            pattern: /\.js$/
+          }
+        })
       )
+    })
+  }
 
-      this.umzug = []
-      this.importMigrationsFromDirectory(config.migrationsDir || ['migrations'])
-    }
-
-    importMigrationsFromDirectory (dir) {
-      (Array.isArray(dir) ? dir : [dir])
-        .map(dir => path.normalize(path.join(api.projectRoot, dir)))
-        .forEach(dir => {
-          this.umzug.push(new Umzug({
-            storage: 'sequelize',
-            storageOptions: {
-              sequelize: this.sequelize
-            },
-            migrations: {
-              params: [
-                this.sequelize.getQueryInterface(),
-                this.sequelize.constructor,
-                () => {
-                  throw new Error('Migration tried to use old style "done" callback. Please upgrade to "umzug" and return a promise instead.')
-                }],
-              path: dir,
-              pattern: /\.js$/
-            }
-          }))
-        })
-    }
-
-    importModelsFromDirectory (dir) {
-      (Array.isArray(dir) ? dir : [dir])
-        .map(dir => path.normalize(path.join(api.projectRoot, dir)))
-        .forEach(dir => {
-          fs.readdirSync(dir).forEach(file => {
-            const filename = path.join(dir, file)
-            if (fs.statSync(filename).isDirectory()) {
-              return this.importModelsFromDirectory(filename)
-            }
-            if (path.extname(file) !== '.js') return
-            const nameParts = file.split('/')
-            const name = nameParts[(nameParts.length - 1)].split('.')[0]
-            const modelFunc = currySchemaFunc(require(filename))
-            this.sequelize.import(name, modelFunc)
-
-            // watch model files for changes
-            api.watchFileAndAct(filename, async () => {
-              config.logging(`*** Rebooting due to model change (${filename}) ***`, 'info')
-              delete require.cache[require.resolve(filename)]
-              delete this.sequelize.importCache[filename]
-              await api.commands.restart()
-            })
-          })
-        })
-    }
-
-    async connect () {
-      this.importModelsFromDirectory(config.modelsDir || 'models')
-      api.models = this.sequelize.models
-      await this.test()
-    }
-
-    async loadFixtures () {
-      if (config.loadFixtures) {
-        const SequelizeFixtures = require('sequelize-fixtures')
-        const options = { log: config.logging }
-        await SequelizeFixtures.loadFile(api.projectRoot + '/test/fixtures/*.{json,yml,js}', api.models, options)
-      }
-    }
-
-    async migrate (options) {
-      options = options === null
-        ? { method: 'up' }
-        : options
-
-      await checkMetaOldSchema()
-      for (const umzug of this.umzug) {
-        await umzug.execute(options)
-      }
-    }
-
-    async autoMigrate () {
-      if (config.autoMigrate === null || config.autoMigrate === undefined || config.autoMigrate) {
-        await checkMetaOldSchema()
-        for (const umzug of this.umzug) {
-          await umzug.up()
+  importModelsFromDirectory (dir) {
+    (Array.isArray(dir) ? dir : [dir]).forEach(dir => {
+      fs.readdirSync(dir).forEach(file => {
+        const filename = path.join(dir, file)
+        if (fs.statSync(filename).isDirectory()) {
+          return this.importModelsFromDirectory(filename)
         }
-      }
-    }
+        if (path.extname(file) !== '.js') return
+        const nameParts = file.split('/')
+        const name = nameParts[nameParts.length - 1].split('.')[0]
+        const modelFunc = currySchemaFunc(require(filename))
+        this.sequelize.import(name, modelFunc)
 
-    async migrateUndo () {
-      await checkMetaOldSchema()
-      for (const umzug of this.umzug) {
-        await umzug.down()
-      }
-    }
+        // watch model files for changes
+        api.watchFileAndAct(filename, async () => {
+          config.logging(
+            `*** Rebooting due to model change (${filename}) ***`,
+            'info'
+          )
+          delete require.cache[require.resolve(filename)]
+          delete this.sequelize.importCache[filename]
+          await api.commands.restart()
+        })
+      })
+    })
+  }
 
-    async test () {
-      let query = 'SELECT NOW()'
-      if (config.dialect === 'mssql') query = 'SELECT GETDATE();'
-      if (config.dialect === 'sqlite') query = "SELECT strftime('%s', 'now');"
+  async connect () {
+    this.importModelsFromDirectory(config.modelsDir || 'models')
+    api.models = this.sequelize.models
+    await this.test()
+  }
 
-      try {
-        await this.sequelize.query(query)
-      } catch (error) {
-        config.logging(error, 'warning')
-        throw error
-      }
-    }
-
-    async close () {
-      return this.sequelize.close()
+  async loadFixtures () {
+    if (config.loadFixtures) {
+      const SequelizeFixtures = require('sequelize-fixtures')
+      const options = { log: config.logging }
+      await SequelizeFixtures.loadFile(
+        config.fixturesMatch || '/test/fixtures/*.{json,yml,js}',
+        api.models,
+        options
+      )
     }
   }
+
+  async migrate (options) {
+    options = options === null ? { method: 'up' } : options
+
+    await checkMetaOldSchema()
+    for (const umzug of this.umzug) {
+      await umzug.execute(options)
+    }
+  }
+
+  async autoMigrate () {
+    if (
+      config.autoMigrate === null ||
+      config.autoMigrate === undefined ||
+      config.autoMigrate
+    ) {
+      await checkMetaOldSchema()
+      for (const umzug of this.umzug) {
+        await umzug.up()
+      }
+    }
+  }
+
+  async migrateUndo () {
+    await checkMetaOldSchema()
+    for (const umzug of this.umzug) {
+      await umzug.down()
+    }
+  }
+
+  async test () {
+    let query = 'SELECT NOW()'
+    if (config.dialect === 'mssql') query = 'SELECT GETDATE();'
+    if (config.dialect === 'sqlite') query = "SELECT strftime('%s', 'now');"
+
+    try {
+      await this.sequelize.query(query)
+    } catch (error) {
+      config.logging(error, 'warning')
+      throw error
+    }
+  }
+
+  async close () {
+    return this.sequelize.close()
+  }
+}
 
 async function checkMetaOldSchema () {
   // Check if we need to upgrade from the old sequelize migration format
   try {
-    const raw = await api.sequelize.sequelize.query('SELECT * FROM SequelizeMeta', { raw: true })
+    const raw = await api.sequelize.sequelize.query(
+      'SELECT * FROM SequelizeMeta',
+      { raw: true }
+    )
     const rows = raw[0]
     if (rows.length && Object.prototype.hasOwnProperty.call(rows[0], 'id')) {
-      throw new Error('Old-style meta-migration table detected - please use `sequelize-cli`\'s `db:migrate:old_schema` to migrate.')
+      throw new Error(
+        "Old-style meta-migration table detected - please use `sequelize-cli`'s `db:migrate:old_schema` to migrate."
+      )
     }
   } catch (error) {
     if (error instanceof Sequelize.DatabaseError) {
       if (api.env !== 'test') {
-        config.logging('No SequelizeMeta table found - creating new table. (Make sure you have \'migrations\' folder in your projectRoot!)')
+        config.logging(
+          "No SequelizeMeta table found - creating new table. (Make sure you have 'migrations' folder in your projectRoot!)"
+        )
       }
     } else {
       throw error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ah-sequelize-plugin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -60,24 +60,24 @@
       "dev": true
     },
     "actionhero": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/actionhero/-/actionhero-19.2.2.tgz",
-      "integrity": "sha512-LLu8/FRHSvcLNVr+XEcE5sNNP/G+l8IooGjtsgEV3/6d2lRLFhXwIeTIMHgmvtN5Uy4ZoIo2m7E3KXSl9qX05A==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/actionhero/-/actionhero-20.0.0.tgz",
+      "integrity": "sha512-+XAvi5q39PaDYyrHV4RrTQbOkfNBqG/9T1AG40Yo9d/wBR6qbV9FHpIEKhTpBZv7SWVPjLc3jHZyc8Y0GlvPvw==",
       "dev": true,
       "requires": {
-        "browser_fingerprint": "^1.0.4",
+        "browser_fingerprint": "^1.0.5",
         "dot-prop": "^5.1.0",
         "etag": "^1.8.1",
         "formidable": "^1.2.1",
         "glob": "^7.1.4",
         "i18n": "^0.8.3",
-        "ioredis": "^4.14.0",
+        "ioredis": "^4.14.1",
         "is-running": "^2.1.0",
         "mime": "^2.4.4",
-        "node-resque": "^5.5.5",
+        "node-resque": "^5.5.7",
         "optimist": "^0.6.1",
         "primus": "^7.3.3",
-        "qs": "^6.8.0",
+        "qs": "^6.9.0",
         "uglify-js": "^3.6.0",
         "uuid": "^3.3.3",
         "winston": "^3.2.1",
@@ -85,9 +85,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -110,45 +110,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "ambi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
-      "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
-      "dev": true,
-      "requires": {
-        "editions": "^1.1.1",
-        "typechecker": "^4.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "typechecker": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz",
-          "integrity": "sha512-4LHc1KMNJ6NDGO+dSM/yNfZQRtp8NN7psYrPHUblD62Dvkwsp3VShsbM78kOgpcmMkRTgvwdKOTjctS+uMllgQ==",
-          "dev": true,
-          "requires": {
-            "editions": "^2.1.0"
-          },
-          "dependencies": {
-            "editions": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
-              "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
-              "dev": true,
-              "requires": {
-                "errlop": "^1.1.1",
-                "semver": "^5.6.0"
-              }
-            }
-          }
-        }
       }
     },
     "ansi-colors": {
@@ -287,10 +248,13 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -535,9 +499,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "colorspace": {
@@ -560,9 +524,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "concat-map": {
@@ -631,12 +595,6 @@
         "which": "^1.2.9"
       }
     },
-    "csextends": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/csextends/-/csextends-1.2.0.tgz",
-      "integrity": "sha512-S/8k1bDTJIwuGgQYmsRoE+8P+ohV32WhQ0l4zqrc0XDdxOhjQQD7/wTZwCzoZX53jSX3V/qwjT+OkPTxWQcmjg==",
-      "dev": true
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -647,12 +605,20 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "debug-log": {
@@ -791,9 +757,9 @@
       }
     },
     "dot-prop": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
-      "integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
@@ -805,15 +771,6 @@
       "integrity": "sha512-ch5OQgvGDK2u8pSZeSYAQaV/lczImd7pMJ7BcEPXmnFVjy4yJIzP6CsODJUTH8mg1tyH1Z2abOiuJO3DjZ/GBw==",
       "dev": true
     },
-    "eachr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
-      "integrity": "sha1-Rm98qhBwj2EFCeMsgHqv5X/BIr8=",
-      "dev": true,
-      "requires": {
-        "typechecker": "^2.0.8"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -823,12 +780,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
-    },
-    "editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-      "dev": true
     },
     "emits": {
       "version": "3.0.0",
@@ -865,33 +816,6 @@
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
       "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==",
       "dev": true
-    },
-    "errlop": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
-      "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
-      "dev": true,
-      "requires": {
-        "editions": "^2.1.2"
-      },
-      "dependencies": {
-        "editions": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
-          "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
-          "dev": true,
-          "requires": {
-            "errlop": "^1.1.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1298,9 +1222,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
       "dev": true
     },
     "execa": {
@@ -1330,23 +1254,6 @@
       "integrity": "sha1-4qN+2HEp+0+VM+io11BiMKU5yQU=",
       "dev": true
     },
-    "extendr": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.1.0.tgz",
-      "integrity": "sha1-MBqgu+pWX00tyPVw8qImEahSe1Y=",
-      "dev": true,
-      "requires": {
-        "typechecker": "~2.0.1"
-      },
-      "dependencies": {
-        "typechecker": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-          "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4=",
-          "dev": true
-        }
-      }
-    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1356,23 +1263,6 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
-      }
-    },
-    "extract-opts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
-      "integrity": "sha1-H6KOunNSxttID4hc63GkaBC+bX0=",
-      "dev": true,
-      "requires": {
-        "typechecker": "~2.0.1"
-      },
-      "dependencies": {
-        "typechecker": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-          "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4=",
-          "dev": true
-        }
       }
     },
     "extsprintf": {
@@ -1400,14 +1290,14 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
       "dev": true
     },
@@ -1519,9 +1409,9 @@
       "dev": true
     },
     "forwarded-for": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-1.0.1.tgz",
-      "integrity": "sha1-59pIFAJRaP/AoQ0/954UFfRq9Gk=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-1.1.0.tgz",
+      "integrity": "sha512-1Yam9ht7GyMXMBvuwJfUYqpdtLVodtT5ee5JMBzGiSwVVeh37ZN8LuOWkNHd6ho2zUxpSZCHuQrt1Vjl2AxDNA==",
       "dev": true
     },
     "fs-minipass": {
@@ -1752,17 +1642,17 @@
       }
     },
     "i18n": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.8.3.tgz",
-      "integrity": "sha1-LYzxwkciYCwgQdAbpq5eqlE4jw4=",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.8.4.tgz",
+      "integrity": "sha512-PvMcG+yqYWXrwgdmCpL+APCGa8lRY0tdlo2cXp9UeR3u4h1bJGqFsgybfmG/MqtL1iDmdaPPPLJebXGrZ1XoMQ==",
       "dev": true,
       "requires": {
         "debug": "*",
-        "make-plural": "^3.0.3",
-        "math-interval-parser": "^1.1.0",
-        "messageformat": "^0.3.1",
+        "make-plural": "^6.0.1",
+        "math-interval-parser": "^2.0.1",
+        "messageformat": "^2.3.0",
         "mustache": "*",
-        "sprintf-js": ">=1.0.3"
+        "sprintf-js": "^1.1.2"
       }
     },
     "iconv-lite": {
@@ -1788,22 +1678,6 @@
       "requires": {
         "minimatch": "^3.0.4"
       }
-    },
-    "ignorefs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ignorefs/-/ignorefs-1.2.0.tgz",
-      "integrity": "sha1-2ln7hYl25KXkNwLM0fKC/byeV1Y=",
-      "dev": true,
-      "requires": {
-        "editions": "^1.3.3",
-        "ignorepatterns": "^1.1.0"
-      }
-    },
-    "ignorepatterns": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
-      "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4=",
-      "dev": true
     },
     "import-fresh": {
       "version": "3.1.0",
@@ -1911,9 +1785,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.0.tgz",
-      "integrity": "sha512-vGzyW9QTdGMjaAPUhMj48Z31mIO5qJLzkbsE5dg+orNi7L5Ph035htmkBZNDTDdDk7kp7e9UJUr+alhRuaWp8g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.1.tgz",
+      "integrity": "sha512-94W+X//GHM+1GJvDk6JPc+8qlM7Dul+9K+lg3/aHixPN7ZGkW6qlvX0DG6At9hWtH2v3B32myfZqWoANUJYGJA==",
       "dev": true,
       "requires": {
         "cluster-key-slot": "^1.1.0",
@@ -1925,23 +1799,6 @@
         "redis-errors": "^1.2.0",
         "redis-parser": "^3.0.0",
         "standard-as-callback": "^2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "is-arrayish": {
@@ -2243,22 +2100,10 @@
       }
     },
     "make-plural": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-3.0.6.tgz",
-      "integrity": "sha1-IDOgO6wpC487uRJY9lud9+iwHKc=",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true,
-          "optional": true
-        }
-      }
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.0.1.tgz",
+      "integrity": "sha512-h0uBNi4tpDkiWUyYKrJNj8Kif6q3Ba5zp/8jnfPy3pQE+4XcTj6h3eZM5SYVUyDNX9Zk69Isr/dx0I+78aJUaQ==",
+      "dev": true
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -2270,13 +2115,10 @@
       }
     },
     "math-interval-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-1.1.0.tgz",
-      "integrity": "sha1-2+2lsGsySZc8bfYXD94jhvCv2JM=",
-      "dev": true,
-      "requires": {
-        "xregexp": "^2.0.0"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
+      "integrity": "sha512-VmlAmb0UJwlvMyx8iPhXUDnVW1F9IrGEd9CIOmv+XL8AErCUUuozoDMrgImvnYt2A+53qVX/tPW6YJurMKYsvA==",
+      "dev": true
     },
     "mem": {
       "version": "4.3.0",
@@ -2298,32 +2140,45 @@
       }
     },
     "messageformat": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-0.3.1.tgz",
-      "integrity": "sha1-5Y//gkXps5cXmeW0PbWLPpQX9aI=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
+      "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
       "dev": true,
       "requires": {
-        "async": "~1.5.2",
-        "glob": "~6.0.4",
-        "make-plural": "~3.0.3",
-        "nopt": "~3.0.6",
-        "watchr": "~2.4.13"
+        "make-plural": "^4.3.0",
+        "messageformat-formatters": "^2.0.1",
+        "messageformat-parser": "^4.1.2"
       },
       "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+        "make-plural": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
+          "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "minimist": "^1.2.0"
           }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
         }
       }
+    },
+    "messageformat-formatters": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
+      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg==",
+      "dev": true
+    },
+    "messageformat-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.2.tgz",
+      "integrity": "sha512-7dWuifeyldz7vhEuL96Kwq1fhZXBW+TUfbnHN4UCrCxoXQTYjHnR78eI66Gk9LaLLsAvzPNVJBaa66DRfFNaiA==",
+      "dev": true
     },
     "millisecond": {
       "version": "0.1.2",
@@ -2560,9 +2415,9 @@
       "dev": true
     },
     "mustache": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.3.tgz",
-      "integrity": "sha512-vM5FkMHamTYmVYeAujypihuPrJQDtaUIlKeeVb1AMJ73OZLtWiF7GprqrjxD0gJWT53W9JfqXxf97nXQjMQkqA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.1.0.tgz",
+      "integrity": "sha512-3Bxq1R5LBZp7fbFPZzFe5WN4s0q3+gxZaZuZVY+QctYJiCiVgXHOTIC0/HgZuOPFt/6BQcx5u0H2CUOxT/RoGQ==",
       "dev": true
     },
     "mute-stream": {
@@ -2578,9 +2433,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.4.tgz",
-      "integrity": "sha512-sOJnBmY3TJQBVIBqKHoifuwygrocXg3NjS9rZSMnVl05XWSHK7Qxb177AIZQyMDjP86bz+yneozj/h9qsPLcCA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.7.tgz",
+      "integrity": "sha512-fmS3qwDldm4bE01HCIRqNk+f255CNjnAoeV3Zzzv0KemObHKqYgirVaZA9DtKcjogicWjYcHkJs4D5A8CjnuVQ==",
       "dev": true
     },
     "natural-compare": {
@@ -2672,21 +2527,12 @@
       }
     },
     "node-resque": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-5.5.5.tgz",
-      "integrity": "sha512-GSVDRvHOep9ggRXnZxRVW3N2N1Z5wBlFRv6T+c5M4UAexoT8HYsnJd+z+aKRjNE215H3PqsvL10L87v4GVO+nQ==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/node-resque/-/node-resque-5.5.7.tgz",
+      "integrity": "sha512-7WcPqQigfVhz9k9LEluRBuyePWtpBIl3/NI6qHO+juWL1voA09MJyWBSZcsi+uxb+FbKWmzBz6+92XARmEz9zA==",
       "dev": true,
       "requires": {
-        "ioredis": "^4.11.1"
-      }
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
+        "ioredis": "^4.14.1"
       }
     },
     "normalize-package-data": {
@@ -3140,20 +2986,20 @@
       "dev": true
     },
     "primus": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/primus/-/primus-7.3.3.tgz",
-      "integrity": "sha512-e/w6bY8I/7Y7gWV/yew9rodf682wNP0sGnHiXstf3WIndzMFBqOwKdbkr89w4MfdaUvZ3SkwwGGieDKuVVSPmQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/primus/-/primus-7.3.4.tgz",
+      "integrity": "sha512-ZLSEak5n0R2odJ609a3Dzlor1zPSDMYMYiAELfnhBumCa57WpvZsY3atjG4CxlPTcNYJ/OV18p+mRYyO1+DMww==",
       "dev": true,
       "requires": {
         "access-control": "~1.0.0",
         "asyncemit": "~3.0.1",
         "create-server": "~1.0.1",
         "diagnostics": "~2.0.0",
-        "eventemitter3": "~3.1.0",
-        "forwarded-for": "~1.0.1",
+        "eventemitter3": "~4.0.0",
+        "forwarded-for": "~1.1.0",
         "fusing": "~1.0.0",
-        "nanoid": "~2.0.0",
-        "setheader": "~1.0.0",
+        "nanoid": "~2.1.0",
+        "setheader": "~1.0.2",
         "ultron": "~1.1.0"
       }
     },
@@ -3203,9 +3049,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
-      "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
       "dev": true
     },
     "rc": {
@@ -3419,15 +3265,6 @@
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true
     },
-    "safefs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.2.2.tgz",
-      "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "*"
-      }
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3439,17 +3276,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
-    },
-    "scandirectory": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-2.5.0.tgz",
-      "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
-      "dev": true,
-      "requires": {
-        "ignorefs": "^1.0.0",
-        "safefs": "^3.1.2",
-        "taskgroup": "^4.0.5"
-      }
     },
     "semver": {
       "version": "5.5.0",
@@ -3516,9 +3342,9 @@
       "dev": true
     },
     "setheader": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/setheader/-/setheader-1.0.1.tgz",
-      "integrity": "sha512-iNDik8ipRBZHfpbpdWlhfZxc0JM9Cg4NYo8jqBkjSRLPxvcgnrE9oiF3AhpFvypg2erVyWNS+QhykhQt0G9tpA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/setheader/-/setheader-1.0.2.tgz",
+      "integrity": "sha512-A704nIwzqGed0CnJZIqDE+0udMPS839ocgf1R9OJ8aq8vw4U980HWeNaD9ec8VnmBni9lyGEWDedOWXT/C5kxA==",
       "dev": true,
       "requires": {
         "diagnostics": "1.x.x"
@@ -3720,12 +3546,6 @@
           "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
           "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
           "dev": true
-        },
-        "eventemitter3": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
-          "dev": true
         }
       }
     },
@@ -3865,16 +3685,6 @@
         "yallist": "^3.0.3"
       }
     },
-    "taskgroup": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-4.3.1.tgz",
-      "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
-      "dev": true,
-      "requires": {
-        "ambi": "^2.2.0",
-        "csextends": "^1.0.3"
-      }
-    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -3974,19 +3784,13 @@
       "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
       "dev": true
     },
-    "typechecker": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.1.0.tgz",
-      "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M=",
-      "dev": true
-    },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       }
     },
@@ -4071,22 +3875,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "watchr": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/watchr/-/watchr-2.4.13.tgz",
-      "integrity": "sha1-10hHu01vkPYf4sdPn2hmKqDgdgE=",
-      "dev": true,
-      "requires": {
-        "eachr": "^2.0.2",
-        "extendr": "^2.1.0",
-        "extract-opts": "^2.2.0",
-        "ignorefs": "^1.0.0",
-        "safefs": "^3.1.2",
-        "scandirectory": "^2.5.0",
-        "taskgroup": "^4.2.0",
-        "typechecker": "^2.0.8"
-      }
-    },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -4128,15 +3916,6 @@
         "winston-transport": "^4.3.0"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "diagnostics": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
@@ -4147,12 +3926,6 @@
             "enabled": "1.0.x",
             "kuler": "1.0.x"
           }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
         }
       }
     },
@@ -4270,19 +4043,13 @@
       }
     },
     "ws": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
-      "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
+      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
       "dev": true,
       "requires": {
         "async-limiter": "^1.0.0"
       }
-    },
-    "xregexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
-      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "ah-sequelize-plugin",
   "license": "MIT",
   "description": "Use Sequelize in ActionHero",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "homepage": "http://actionherojs.com",
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
     "umzug": "^2.2.0"
   },
   "devDependencies": {
-    "actionhero": "^19.2.2",
+    "actionhero": "^20.0.0",
     "chai": "^4.2.0",
     "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",

--- a/test/config/sequelize.js
+++ b/test/config/sequelize.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 exports.test = {
   sequelize: () => {
     return {
@@ -6,8 +8,8 @@ exports.test = {
       dialect: 'sqlite',
       storage: ':memory:',
       host: 'localhost',
-      modelsDir: ['models', 'plugins/test-plugin/models'],
-      migrationsDir: ['migrations', 'plugins/test-plugin/migrations']
+      modelsDir: [path.join(__dirname, '..', 'models'), path.join(__dirname, '..', 'plugins/test-plugin/models')],
+      migrationsDir: [path.join(__dirname, '..', 'migrations'), path.join(__dirname, '..', 'plugins/test-plugin/migrations')]
     }
   }
 }


### PR DESCRIPTION
For the Typescript version of Actionhero (v21), we need to be able to account for projects which have both a `src` and a `dist` directory.  This means that we cannot rely on models & migrations being relative to project root... that will change depending on which more you are running in.

This change changes the config setup for ah-sequelzie-plugin to instead search for those folders relative to the config file (which will be compiled as needed itself into `dist` or `src)`