### PR TITLE
Lock umzug version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "umzug": "^v3.0.0-beta.5"
+    "umzug": "v3.0.0-beta.5"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.32",


### PR DESCRIPTION
Since the `umzug` beta namespace seems to have breaking changes (https://github.com/actionhero/ah-sequelize-plugin/pull/201) , we need to only use a specific version of `umzug`