### PR TITLE
Inject schema to Sequelize QueryInterface functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ export const DEFAULT = {
       schema: schema,
       searchPath: schema,
       dialectOptions: { prependSearchPath: true }, // Merge this one if it already exists.
-      functionsToInjectSchemaIn: ["addColumn", "removeColumn", "renameColumn"], // This config is needed if you are using one of these functions on your migrations.
     };
   },
 };

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ export const DEFAULT = {
       migrations: [join(__dirname, "..", "migrations")],
       migrationLogLevel: "info",
       // you can also pass "dialectOptions", for example if you need `{ssl: true}` for Postgres
+      // If you want to change the schema you need to include the following configs:
+      schema: schema,
+      searchPath: schema,
+      dialectOptions: { prependSearchPath: true }, // Merge this one if it already exists.
+      functionsToInjectSchemaIn: ["addColumn", "removeColumn", "renameColumn"], // This config is needed if you are using one of these functions on your migrations.
     };
   },
 };

--- a/src/initializers/sequelize.ts
+++ b/src/initializers/sequelize.ts
@@ -2,7 +2,6 @@ import { Sequelize } from "sequelize-typescript";
 import { Umzug, SequelizeStorage } from "umzug";
 import { api, log, config, Initializer } from "actionhero";
 import * as path from "path";
-import { QueryInterface } from "sequelize";
 
 declare module "actionhero" {
   export interface Api {


### PR DESCRIPTION
 - extend Sequelize QueryInterface functions to support custom schema;
 - get the functions names from config (functionsToInjectSchemaIn).