### PR TITLE
Update migration names to remove file extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           command: npm run lint
       - run:
           name: test
-          command: ./node_modules/.bin/jest --ci
+          command: ./node_modules/.bin/jest --ci --forceExit
 
 workflows:
   version: 2

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -7,8 +7,13 @@ describe("ah-sequelize-plugin", function () {
   const actionhero = new Process();
 
   beforeAll(async () => {
-    await actionhero.start();
-    await truncate([User, Post]);
+    try {
+      await actionhero.start();
+      await truncate([User, Post]);
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
   });
 
   afterAll(async () => await actionhero.stop());

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -138,4 +138,29 @@ describe("ah-sequelize-plugin", function () {
     const count = await User.count();
     expect(count).toBe(0);
   });
+
+  describe("migration name update", () => {
+    beforeAll(async () => {
+      await api.sequelize.query(
+        "INSERT INTO \"SequelizeMeta\" (\"name\") VALUES ('0003-js-test.js'), ('0004-ts-test.ts')"
+      );
+      await actionhero.restart();
+    });
+
+    afterAll(async () => {
+      await api.sequelize.query(
+        "DELETE FROM \"SequelizeMeta\" WHERE \"name\" IN ('0003-js-test.js', '0004-ts-test.ts', '0003-js-test', '0004-ts-test')"
+      );
+    });
+
+    test("migration names with file extensions are fixed", async () => {
+      const [rows] = await api.sequelize.query('SELECT * FROM "SequelizeMeta"');
+      expect(rows).toEqual([
+        { name: "0001-createUsersTable" },
+        { name: "0002-createPostsTable" },
+        { name: "0003-js-test" },
+        { name: "0004-ts-test" },
+      ]);
+    });
+  });
 });

--- a/__tests__/utils/truncate.ts
+++ b/__tests__/utils/truncate.ts
@@ -1,5 +1,10 @@
 export async function truncate(models: Array<any>) {
-  await Promise.all(
-    models.map((model) => model.destroy({ truncate: true, force: true }))
-  );
+  try {
+    await Promise.all(
+      models.map((model) => model.destroy({ truncate: true, force: true }))
+    );
+  } catch (error) {
+    console.error(error); // jest has trouble showing the fill DB error
+    throw error;
+  }
 }

--- a/src/modules/migrations.ts
+++ b/src/modules/migrations.ts
@@ -71,10 +71,11 @@ export namespace Migrations {
     logger: MigrationLogger,
     logLevel: string
   ) {
-    const umzugs: Umzug[] = [];
-    for (const dir of Array.isArray(sequelizeConfig.migrations)
+    const dirs: string[] = Array.isArray(sequelizeConfig.migrations)
       ? sequelizeConfig.migrations
-      : [sequelizeConfig.migrations]) {
+      : [sequelizeConfig.migrations];
+    const umzugs: Umzug[] = [];
+    for (const dir of dirs) {
       const context = sequelizeInstance.getQueryInterface();
 
       const umzug = new Umzug({

--- a/src/modules/migrations.ts
+++ b/src/modules/migrations.ts
@@ -72,7 +72,7 @@ export namespace Migrations {
     logLevel: string
   ) {
     const umzugs: Umzug[] = [];
-    for (const dir in Array.isArray(sequelizeConfig.migrations)
+    for (const dir of Array.isArray(sequelizeConfig.migrations)
       ? sequelizeConfig.migrations
       : [sequelizeConfig.migrations]) {
       const context = sequelizeInstance.getQueryInterface();
@@ -109,7 +109,8 @@ export namespace Migrations {
       //   and silently matched them. Now, we need to remove the filename prefixes in the
       //   database to match the migration names.
       // We are doing the name update in JS rather than SQL to avoid dialect-specific commands.
-      const rows = await context.sequelize.models.SequelizeMeta.findAll({
+      const model = context.sequelize.models.SequelizeMeta;
+      const rows = await model.findAll({
         where: {
           name: { [Op.or]: [{ [Op.like]: "%.js" }, { [Op.like]: "%.ts" }] },
         },
@@ -119,10 +120,7 @@ export namespace Migrations {
         // @ts-ignore
         const oldName: string = row.name;
         const newName = oldName.replace(/\.ts$/, "").replace(/\.js$/, "");
-        await context.sequelize.models.SequelizeMeta.update(
-          { name: newName },
-          { where: { name: oldName } }
-        );
+        await model.update({ name: newName }, { where: { name: oldName } });
         logger(
           `[migration] renamed migration '${oldName}' to '${newName}'`,
           logLevel


### PR DESCRIPTION
Older versions of Umzug would have allowed .ts and .js names in the migration and silently matched them. Now, we need to remove the filename prefixes in the database to match the migration names.

We are doing the name update in JS rather than SQL to avoid dialect-specific commands.