### PR TITLE
Do not test with try/catch

### DIFF
--- a/src/modules/migrations.ts
+++ b/src/modules/migrations.ts
@@ -111,35 +111,23 @@ export namespace Migrations {
       //   database to match the migration names.
       // We are doing the name update in JS rather than SQL to avoid dialect-specific commands.
       const model = context.sequelize.models.SequelizeMeta;
-      let metaTableExists = false;
-      try {
-        await model.findOne();
-        metaTableExists = true;
-      } catch (error) {
-        if (error.name === "SequelizeDatabaseError") {
-          // it's ok, the table doesn't exist yet
-        } else {
-          throw error;
-        }
-      }
+      await model.sync();
 
-      if (metaTableExists) {
-        const rows = await model.findAll({
-          where: {
-            name: { [Op.or]: [{ [Op.like]: "%.js" }, { [Op.like]: "%.ts" }] },
-          },
-        });
+      const rows = await model.findAll({
+        where: {
+          name: { [Op.or]: [{ [Op.like]: "%.js" }, { [Op.like]: "%.ts" }] },
+        },
+      });
 
-        for (const row of rows) {
-          // @ts-ignore
-          const oldName: string = row.name;
-          const newName = oldName.replace(/\.ts$/, "").replace(/\.js$/, "");
-          await model.update({ name: newName }, { where: { name: oldName } });
-          logger(
-            `[migration] renamed migration '${oldName}' to '${newName}'`,
-            logLevel
-          );
-        }
+      for (const row of rows) {
+        // @ts-ignore
+        const oldName: string = row.name;
+        const newName = oldName.replace(/\.ts$/, "").replace(/\.js$/, "");
+        await model.update({ name: newName }, { where: { name: oldName } });
+        logger(
+          `[migration] renamed migration '${oldName}' to '${newName}'`,
+          logLevel
+        );
       }
 
       umzugs.push(umzug);


### PR DESCRIPTION
Testing if a table exists with try catch is a bad idea because it will poison any transactions in use within the migration.  Instead, we can always ensure that the `SequelzieMeta` table exists by calling `model.sync()`